### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.4](https://github.com/syncable-dev/syncable-cli/compare/v0.1.3...v0.1.4) - 2025-06-05
+
+### Added
+
+- added cargo isntall command for readme
 - Add new features and improvements here.
 
 ## [0.1.3] - 2024-06-05

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/syncable-dev/syncable-cli/compare/v0.1.3...v0.1.4) - 2025-06-05

### Added

- added cargo isntall command for readme
- Add new features and improvements here.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).