### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/syncable-dev/syncable-cli/compare/v0.1.4...v0.1.5) - 2025-06-06
+
+### Added
+
+- cargo lock update
+
+### Other
+
+- Feature/update dependabot ([#11](https://github.com/syncable-dev/syncable-cli/pull/11))
+- Update README.md
+- Update README.md
+- *(deps)* bump reqwest from 0.11.27 to 0.12.19
+- *(deps)* bump dirs from 5.0.1 to 6.0.0
+- Feature/dependabot ([#3](https://github.com/syncable-dev/syncable-cli/pull/3))
+
 ## [0.1.4](https://github.com/syncable-dev/syncable-cli/compare/v0.1.3...v0.1.4) - 2025-06-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/syncable-dev/syncable-cli/compare/v0.1.4...v0.1.5) - 2025-06-06

### Added

- cargo lock update

### Other

- Feature/update dependabot ([#11](https://github.com/syncable-dev/syncable-cli/pull/11))
- Update README.md
- Update README.md
- *(deps)* bump reqwest from 0.11.27 to 0.12.19
- *(deps)* bump dirs from 5.0.1 to 6.0.0
- Feature/dependabot ([#3](https://github.com/syncable-dev/syncable-cli/pull/3))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).