### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/syncable-dev/syncable-cli/compare/v0.1.5...v0.2.0) - 2025-06-06
+
+### Added
+
+- Added tool install verifier with cli calls ([#14](https://github.com/syncable-dev/syncable-cli/pull/14))
+
 ## [0.1.5](https://github.com/syncable-dev/syncable-cli/compare/v0.1.4...v0.1.5) - 2025-06-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.1.5 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant Commands:Tools in /tmp/.tmptGRtJn/syncable-cli/src/cli.rs:206
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/syncable-dev/syncable-cli/compare/v0.1.5...v0.2.0) - 2025-06-06

### Added

- Added tool install verifier with cli calls ([#14](https://github.com/syncable-dev/syncable-cli/pull/14))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).