### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/syncable-dev/syncable-cli/compare/v0.2.0...v0.2.1) - 2025-06-06
+
+### Other
+
+- Feature/add automatic cli update ([#22](https://github.com/syncable-dev/syncable-cli/pull/22))
+
 ## [0.2.0](https://github.com/syncable-dev/syncable-cli/compare/v0.1.5...v0.2.0) - 2025-06-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/syncable-dev/syncable-cli/compare/v0.2.0...v0.2.1) - 2025-06-06

### Other

- Feature/add automatic cli update ([#22](https://github.com/syncable-dev/syncable-cli/pull/22))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).