### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/syncable-dev/syncable-cli/compare/v0.2.1...v0.3.0) - 2025-06-06
+
+### Added
+
+- Added tool install verifier with cli calls ([#14](https://github.com/syncable-dev/syncable-cli/pull/14))
+
+### Other
+
+- Feature/extendsive docker compose and docker scan ([#25](https://github.com/syncable-dev/syncable-cli/pull/25))
+- Feature/add automatic cli update ([#22](https://github.com/syncable-dev/syncable-cli/pull/22))
+- Feature/update dependabot ([#11](https://github.com/syncable-dev/syncable-cli/pull/11))
+
 ## [0.2.1](https://github.com/syncable-dev/syncable-cli/compare/v0.2.0...v0.2.1) - 2025-06-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ProjectAnalysis.docker_analysis in /tmp/.tmpzhvalO/syncable-cli/src/analyzer/mod.rs:231
  field ProjectAnalysis.docker_analysis in /tmp/.tmpzhvalO/syncable-cli/src/analyzer/mod.rs:231
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/syncable-dev/syncable-cli/compare/v0.2.1...v0.3.0) - 2025-06-06

### Added

- Added tool install verifier with cli calls ([#14](https://github.com/syncable-dev/syncable-cli/pull/14))

### Other

- Feature/extendsive docker compose and docker scan ([#25](https://github.com/syncable-dev/syncable-cli/pull/25))
- Feature/add automatic cli update ([#22](https://github.com/syncable-dev/syncable-cli/pull/22))
- Feature/update dependabot ([#11](https://github.com/syncable-dev/syncable-cli/pull/11))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).