### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/syncable-dev/syncable-cli/compare/v0.4.2...v0.5.0) - 2025-06-06
+
+### Other
+
+- HOTFIX - hoping auto update becomes available
+
 ## [0.4.2](https://github.com/syncable-dev/syncable-cli/compare/v0.4.1...v0.4.2) - 2025-06-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.4.2 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Cli.clear_update_cache in /tmp/.tmpGHRuIc/syncable-cli/src/cli.rs:31
  field SecurityAnalysisConfig.skip_gitignored_files in /tmp/.tmpGHRuIc/syncable-cli/src/analyzer/security_analyzer.rs:128
  field SecurityAnalysisConfig.downgrade_gitignored_severity in /tmp/.tmpGHRuIc/syncable-cli/src/analyzer/security_analyzer.rs:130
  field SecurityAnalysisConfig.skip_gitignored_files in /tmp/.tmpGHRuIc/syncable-cli/src/analyzer/security_analyzer.rs:128
  field SecurityAnalysisConfig.downgrade_gitignored_severity in /tmp/.tmpGHRuIc/syncable-cli/src/analyzer/security_analyzer.rs:130
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/syncable-dev/syncable-cli/compare/v0.4.2...v0.5.0) - 2025-06-06

### Other

- HOTFIX - hoping auto update becomes available
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).