### PR TITLE
chore: release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/syncable-dev/syncable-cli/compare/v0.5.2...v0.5.3) - 2025-06-07
+
+### Other
+
+- Develop ([#47](https://github.com/syncable-dev/syncable-cli/pull/47))
+- Update README.md
+
 ## [0.5.2](https://github.com/syncable-dev/syncable-cli/compare/v0.5.1...v0.5.2) - 2025-06-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.5.2 -> 0.5.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.3](https://github.com/syncable-dev/syncable-cli/compare/v0.5.2...v0.5.3) - 2025-06-07

### Other

- Develop ([#47](https://github.com/syncable-dev/syncable-cli/pull/47))
- Update README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).