### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/syncable-dev/syncable-cli/compare/v0.5.4...v0.6.0) - 2025-06-07
+
+### Added
+
+- improved readme
+
+### Fixed
+
+- release-plz structure to avoid quick bump
+
+### Other
+
+- fix releaze-pls, proper section structure
+- wrong release-plz setting
+- small updates of unnused variables - cleanup
+- updated release cycles and rules
+
 ## [0.5.4](https://github.com/syncable-dev/syncable-cli/compare/v0.5.3...v0.5.4) - 2025-06-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.5.4 -> 0.6.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/syncable-dev/syncable-cli/compare/v0.5.4...v0.6.0) - 2025-06-07

### Added

- improved readme

### Fixed

- release-plz structure to avoid quick bump

### Other

- fix releaze-pls, proper section structure
- wrong release-plz setting
- small updates of unnused variables - cleanup
- updated release cycles and rules
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).