### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/syncable-dev/syncable-cli/compare/v0.7.0...v0.8.0) - 2025-06-08
+
+### Added
+
+- feat added python security scanning catching generat exposure secrets similar to javascript version
+
 ## [0.7.0](https://github.com/syncable-dev/syncable-cli/compare/v0.6.0...v0.7.0) - 2025-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant SecurityCategory:CodeInjection in /tmp/.tmp5yoIYY/syncable-cli/src/analyzer/security/core.rs:39
  variant SecurityCategory:CommandInjection in /tmp/.tmp5yoIYY/syncable-cli/src/analyzer/security/core.rs:41
  variant SecurityCategory:CodeInjection in /tmp/.tmp5yoIYY/syncable-cli/src/analyzer/security/core.rs:39
  variant SecurityCategory:CommandInjection in /tmp/.tmp5yoIYY/syncable-cli/src/analyzer/security/core.rs:41
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/syncable-dev/syncable-cli/compare/v0.7.0...v0.8.0) - 2025-06-08

### Added

- feat added python security scanning catching generat exposure secrets similar to javascript version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).