### PR TITLE
chore: release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/syncable-dev/syncable-cli/compare/v0.9.2...v0.9.3) - 2025-06-10
+
+### Other
+
+- *(deps)* bump thiserror from 1.0.69 to 2.0.12
+
 ## [0.9.2](https://github.com/syncable-dev/syncable-cli/compare/v0.9.1...v0.9.2) - 2025-06-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.9.2 -> 0.9.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.3](https://github.com/syncable-dev/syncable-cli/compare/v0.9.2...v0.9.3) - 2025-06-10

### Other

- *(deps)* bump thiserror from 1.0.69 to 2.0.12
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).