### PR TITLE
chore: release v0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.9.6](https://github.com/syncable-dev/syncable-cli/compare/v0.9.5...v0.9.6) - 2025-06-11
+
+### Other
+
+- *(deps)* bump rustsec from 0.29.3 to 0.30.2
+
 ## [0.9.5](https://github.com/syncable-dev/syncable-cli/compare/v0.9.4...v0.9.5) - 2025-06-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.9.5 -> 0.9.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.6](https://github.com/syncable-dev/syncable-cli/compare/v0.9.5...v0.9.6) - 2025-06-11

### Other

- *(deps)* bump rustsec from 0.29.3 to 0.30.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).