### PR TITLE
chore: release v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.9.8](https://github.com/syncable-dev/syncable-cli/compare/v0.9.7...v0.9.8) - 2025-06-12
+
+### Other
+
+- *(deps)* bump env_logger from 0.10.2 to 0.11.8
+
 ## [0.9.7](https://github.com/syncable-dev/syncable-cli/compare/v0.9.6...v0.9.7) - 2025-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.9.7 -> 0.9.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.8](https://github.com/syncable-dev/syncable-cli/compare/v0.9.7...v0.9.8) - 2025-06-12

### Other

- *(deps)* bump env_logger from 0.10.2 to 0.11.8
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).