### PR TITLE
chore: release v0.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.9.11](https://github.com/syncable-dev/syncable-cli/compare/v0.9.10...v0.9.11) - 2025-06-18
+
+### Added
+
+- added return value for handler_analyze to utilize within MCP servers
+- exposing commands for lib
+- added public refferences to main methods for mcp access
+
+### Other
+
+- Merge branch 'main' of github.com:syncable-dev/syncable-cli into develop
+
 ## [0.9.10](https://github.com/syncable-dev/syncable-cli/compare/v0.9.9...v0.9.10) - 2025-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.9.10 -> 0.9.11 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.11](https://github.com/syncable-dev/syncable-cli/compare/v0.9.10...v0.9.11) - 2025-06-18

### Added

- added return value for handler_analyze to utilize within MCP servers
- exposing commands for lib
- added public refferences to main methods for mcp access

### Other

- Merge branch 'main' of github.com:syncable-dev/syncable-cli into develop
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).