### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/syncable-dev/syncable-cli/compare/v0.9.11...v0.10.0) - 2025-06-18
+
+### Added
+
+- refactored display
+
 ## [0.9.11](https://github.com/syncable-dev/syncable-cli/compare/v0.9.10...v0.9.11) - 2025-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.9.11"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.9.11"
+version = "0.10.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.9.11 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function syncable_cli::analyzer::display::display_summary_view, previously in file /tmp/.tmpCpDRgT/syncable-cli/src/analyzer/display.rs:1397
  function syncable_cli::analyzer::display::display_summary_view_to_string, previously in file /tmp/.tmpCpDRgT/syncable-cli/src/analyzer/display.rs:1439
  function syncable_cli::analyzer::display::display_matrix_view, previously in file /tmp/.tmpCpDRgT/syncable-cli/src/analyzer/display.rs:439
  function syncable_cli::analyzer::display::display_json_view, previously in file /tmp/.tmpCpDRgT/syncable-cli/src/analyzer/display.rs:1423
  function syncable_cli::analyzer::display::display_detailed_view_to_string, previously in file /tmp/.tmpCpDRgT/syncable-cli/src/analyzer/display.rs:1469
  function syncable_cli::analyzer::display::display_matrix_view_to_string, previously in file /tmp/.tmpCpDRgT/syncable-cli/src/analyzer/display.rs:471
  function syncable_cli::analyzer::display::display_detailed_view, previously in file /tmp/.tmpCpDRgT/syncable-cli/src/analyzer/display.rs:1014
  function syncable_cli::analyzer::display::display_json_view_to_string, previously in file /tmp/.tmpCpDRgT/syncable-cli/src/analyzer/display.rs:1431
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/syncable-dev/syncable-cli/compare/v0.9.11...v0.10.0) - 2025-06-18

### Added

- refactored display
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).