### PR TITLE
chore: release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/syncable-dev/syncable-cli/compare/v0.10.0...v0.10.1) - 2025-06-19
+
+### Added
+
+- refactored handler logic - on to huge simplification and code breakdown
+
 ## [0.10.0](https://github.com/syncable-dev/syncable-cli/compare/v0.9.11...v0.10.0) - 2025-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.10.0 -> 0.10.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.1](https://github.com/syncable-dev/syncable-cli/compare/v0.10.0...v0.10.1) - 2025-06-19

### Added

- refactored handler logic - on to huge simplification and code breakdown
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).