### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/syncable-dev/syncable-cli/compare/v0.10.2...v0.11.0) - 2025-06-19
+
+### Added
+
+- feat; improved security:scaning printout
+- returning dependencies as a string, for MCP server opportunity
+- refactored handler logic - on to huge simplification and code breakdown
+
 ## [0.10.2](https://github.com/syncable-dev/syncable-cli/compare/v0.10.1...v0.10.2) - 2025-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.10.2 -> 0.11.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  syncable_cli::analyzer::security::turbo::pattern_engine::PatternEngine::scan_content now takes 4 parameters instead of 3, in /tmp/.tmpNUfVL2/syncable-cli/src/analyzer/security/turbo/pattern_engine.rs:94
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/syncable-dev/syncable-cli/compare/v0.10.2...v0.11.0) - 2025-06-19

### Added

- feat; improved security:scaning printout
- returning dependencies as a string, for MCP server opportunity
- refactored handler logic - on to huge simplification and code breakdown
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).