### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/syncable-dev/syncable-cli/compare/v0.11.1...v0.12.0) - 2025-07-02
+
+### Added
+
+- wrong named services
+- test
+- new cargo lock
+- fixed double print
+
+### Other
+
+- t
+- Merge branch 'main' of github.com:syncable-dev/syncable-cli into develop
+- *(deps)* bump indicatif from 0.17.11 to 0.17.12
+- *(deps)* bump reqwest from 0.12.20 to 0.12.21
+- *(deps)* bump dashmap from 5.5.3 to 6.1.0
+- *(deps)* bump rustsec from 0.30.2 to 0.30.4
+
 ## [0.11.1](https://github.com/syncable-dev/syncable-cli/compare/v0.11.0...v0.11.1) - 2025-06-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.11.1 -> 0.12.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function syncable_cli::analyzer::project_context::analyze_context, previously in file /tmp/.tmpF5PuTl/syncable-cli/src/analyzer/project_context.rs:26
  function syncable_cli::analyzer::monorepo_detector::analyze_monorepo_with_config, previously in file /tmp/.tmpF5PuTl/syncable-cli/src/analyzer/monorepo_detector.rs:58
  function syncable_cli::analyzer::monorepo_detector::analyze_monorepo, previously in file /tmp/.tmpF5PuTl/syncable-cli/src/analyzer/monorepo_detector.rs:53

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod syncable_cli::analyzer::monorepo_detector, previously in file /tmp/.tmpF5PuTl/syncable-cli/src/analyzer/monorepo_detector.rs:1
  mod syncable_cli::analyzer::project_context, previously in file /tmp/.tmpF5PuTl/syncable-cli/src/analyzer/project_context.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct syncable_cli::analyzer::monorepo_detector::MonorepoDetectionConfig, previously in file /tmp/.tmpF5PuTl/syncable-cli/src/analyzer/monorepo_detector.rs:14
  struct syncable_cli::analyzer::project_context::ProjectContext, previously in file /tmp/.tmpF5PuTl/syncable-cli/src/analyzer/project_context.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.0](https://github.com/syncable-dev/syncable-cli/compare/v0.11.1...v0.12.0) - 2025-07-02

### Added

- wrong named services
- test
- new cargo lock
- fixed double print

### Other

- t
- Merge branch 'main' of github.com:syncable-dev/syncable-cli into develop
- *(deps)* bump indicatif from 0.17.11 to 0.17.12
- *(deps)* bump reqwest from 0.12.20 to 0.12.21
- *(deps)* bump dashmap from 5.5.3 to 6.1.0
- *(deps)* bump rustsec from 0.30.2 to 0.30.4
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).