### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.13.0](https://github.com/syncable-dev/syncable-cli/compare/v0.12.1...v0.13.0) - 2025-07-30
+
+### Added
+
+- updated color mode discovery
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.12.1 -> 0.13.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field color_scheme of variant Commands::Analyze in /tmp/.tmpcY326x/syncable-cli/src/cli.rs:62

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_parameter_count_changed.ron

Failed in:
  syncable_cli::handlers::analyze::handle_analyze now takes 6 parameters instead of 5, in /tmp/.tmpcY326x/syncable-cli/src/handlers/analyze.rs:10
  syncable_cli::analyze::handle_analyze now takes 6 parameters instead of 5, in /tmp/.tmpcY326x/syncable-cli/src/handlers/analyze.rs:10
  syncable_cli::handlers::handle_analyze now takes 6 parameters instead of 5, in /tmp/.tmpcY326x/syncable-cli/src/handlers/analyze.rs:10
  syncable_cli::handle_analyze now takes 6 parameters instead of 5, in /tmp/.tmpcY326x/syncable-cli/src/handlers/analyze.rs:10
```

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).