### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/syncable-dev/syncable-cli/compare/v0.13.0...v0.13.1) - 2025-08-01
+
+### Added
+
+- updated color mode discovery
+
+### Other
+
+- Merge branch 'main' into develop
+- *(deps)* bump toml from 0.8.23 to 0.9.3
+- *(deps)* bump tokio from 1.46.1 to 1.47.0
+- Merge pull request #114 from syncable-dev/dependabot/cargo/develop/tokio-1.46.1
+
 ## [0.13.0](https://github.com/syncable-dev/syncable-cli/compare/v0.12.1...v0.13.0) - 2025-07-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -3735,7 +3735,6 @@ name = "tokio"
 version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
-
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.13.0 -> 0.13.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).