### PR TITLE
chore(deps): bump memmap2 from 0.9.5 to 0.9.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,9 +2312,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: memmap2 dependency-version: 0.9.7 dependency-type: direct:production update-type: version-update:semver-patch ...