### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/syncable-dev/syncable-cli/compare/v0.13.6...v0.14.0) - 2025-09-09
+
+### Added
+
+- added further refactor
+- improved vulnerablity scanner for more that just npm audit but also bun, yarn & pnpm
+
+### Other
+
+- Merge branch 'main' of github.com:syncable-dev/syncable-cli into develop
+- Merge branch 'develop' of github.com:syncable-dev/syncable-cli into develop
+
 ### Added
 - 🧄 **Bun Runtime Integration**: Complete support for Bun JavaScript runtime and package manager
   - Automatic Bun project detection via `bun.lockb`, `bunfig.toml`, and package.json configuration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.13.6"
+version = "0.14.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.13.6"
+version = "0.14.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.13.6 -> 0.14.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_missing.ron

Failed in:
  enum syncable_cli::analyzer::vulnerability_checker::VulnerabilitySeverity, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/vulnerability_checker.rs:55
  enum syncable_cli::analyzer::vulnerability_checker::VulnerabilityError, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/vulnerability_checker.rs:17
  enum syncable_cli::analyzer::VulnerabilitySeverity, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/dependency_parser.rs:78

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field detailed of variant ToolsCommand::Verify in /tmp/.tmp5c2BgR/syncable-cli/src/cli.rs:270

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field verbose of variant ToolsCommand::Verify, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/cli.rs:270

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/module_missing.ron

Failed in:
  mod syncable_cli::analyzer::vulnerability_checker, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/vulnerability_checker.rs:1
  mod syncable_cli::analyzer::tool_installer, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/tool_installer.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct syncable_cli::analyzer::tool_installer::ToolInstaller, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/tool_installer.rs:9
  struct syncable_cli::analyzer::vulnerability_checker::VulnerabilityChecker, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/vulnerability_checker.rs:82
  struct syncable_cli::analyzer::vulnerability_checker::VulnerabilityInfo, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/vulnerability_checker.rs:41
  struct syncable_cli::analyzer::vulnerability_checker::VulnerableDependency, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/vulnerability_checker.rs:75
  struct syncable_cli::analyzer::Vulnerability, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/dependency_parser.rs:70
  struct syncable_cli::analyzer::vulnerability_checker::VulnerabilityReport, previously in file /tmp/.tmpYH3GC9/syncable-cli/src/analyzer/vulnerability_checker.rs:64
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.14.0](https://github.com/syncable-dev/syncable-cli/compare/v0.13.6...v0.14.0) - 2025-09-09

### Added

- added further refactor
- improved vulnerablity scanner for more that just npm audit but also bun, yarn & pnpm

### Other

- Merge branch 'main' of github.com:syncable-dev/syncable-cli into develop
- Merge branch 'develop' of github.com:syncable-dev/syncable-cli into develop
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).