### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/syncable-dev/syncable-cli/compare/v0.14.0...v0.15.0) - 2025-09-10
+
+### Added
+
+- fixed errors
+- removed warnings
+
+### Other
+
+- fixed vulnerabilities report
+
 ## [0.14.0](https://github.com/syncable-dev/syncable-cli/compare/v0.13.6...v0.14.0) - 2025-09-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.14.0 -> 0.15.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure unit_struct_changed_kind: unit struct changed kind ---

Description:
A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
        ref: https://github.com/rust-lang/cargo/pull/10871
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/unit_struct_changed_kind.ron

Failed in:
  struct JavaScriptVulnerabilityChecker in /tmp/.tmps6ASNh/syncable-cli/src/analyzer/vulnerability/checkers/javascript.rs:10
  struct JavaScriptVulnerabilityChecker in /tmp/.tmps6ASNh/syncable-cli/src/analyzer/vulnerability/checkers/javascript.rs:10
  struct JavaScriptVulnerabilityChecker in /tmp/.tmps6ASNh/syncable-cli/src/analyzer/vulnerability/checkers/javascript.rs:10
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.15.0](https://github.com/syncable-dev/syncable-cli/compare/v0.14.0...v0.15.0) - 2025-09-10

### Added

- fixed errors
- removed warnings

### Other

- fixed vulnerabilities report
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).