### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/syncable-dev/syncable-cli/compare/v0.15.0...v0.16.0) - 2025-09-10
+
+### Added
+
+- open-telemtry added and improved techonology scannings
+
+### Other
+
+- removed telemtry for start/complete phases
+
 ## [0.15.0](https://github.com/syncable-dev/syncable-cli/compare/v0.14.0...v0.15.0) - 2025-09-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.15.0 -> 0.16.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Cli.disable_telemetry in /tmp/.tmptRgM7H/syncable-cli/src/cli.rs:37
  field Config.telemetry in /tmp/.tmptRgM7H/syncable-cli/src/config/types.rs:9
  field TechnologyRule.file_indicators in /tmp/.tmptRgM7H/syncable-cli/src/analyzer/frameworks/mod.rs:36
  field DetectedTechnology.file_indicators in /tmp/.tmptRgM7H/syncable-cli/src/analyzer/mod.rs:142
  field DetectedTechnology.file_indicators in /tmp/.tmptRgM7H/syncable-cli/src/analyzer/mod.rs:142
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.16.0](https://github.com/syncable-dev/syncable-cli/compare/v0.15.0...v0.16.0) - 2025-09-10

### Added

- open-telemtry added and improved techonology scannings

### Other

- removed telemtry for start/complete phases
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).