### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/syncable-dev/syncable-cli/compare/v0.16.0...v0.17.0) - 2025-09-11
+
+### Added
+
+- test trigger
+- improved telemtry and removed dublets
+
+### Fixed
+
+- .qodor folder for some reason wasn't corectly ignored
+
+### Other
+
+- added privacy-policy for telemetry
+- fixed vulnerabilities output for different languages
+
 ## [0.12.1](https://github.com/syncable-dev/syncable-cli/compare/v0.12.0...v0.12.1) - 2025-07-09
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.16.0 -> 0.17.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VulnerabilityInfo.vuln_type in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/types.rs:31
  field VulnerabilityInfo.vuln_type in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/types.rs:31
  field VulnerabilityInfo.vuln_type in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/types.rs:31

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  syncable_cli::telemetry::TelemetryClient::track_analyze now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:98
  syncable_cli::telemetry::TelemetryClient::track_generate now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:102
  syncable_cli::telemetry::TelemetryClient::track_validate now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:106
  syncable_cli::telemetry::TelemetryClient::track_support now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:110
  syncable_cli::telemetry::TelemetryClient::track_dependencies now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:114
  syncable_cli::telemetry::TelemetryClient::track_vulnerabilities now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:119
  syncable_cli::telemetry::TelemetryClient::track_security now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:124
  syncable_cli::telemetry::TelemetryClient::track_tools now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:128
  syncable_cli::telemetry::TelemetryClient::track_analyze_folder now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:138
  syncable_cli::TelemetryClient::track_analyze now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:98
  syncable_cli::TelemetryClient::track_generate now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:102
  syncable_cli::TelemetryClient::track_validate now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:106
  syncable_cli::TelemetryClient::track_support now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:110
  syncable_cli::TelemetryClient::track_dependencies now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:114
  syncable_cli::TelemetryClient::track_vulnerabilities now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:119
  syncable_cli::TelemetryClient::track_security now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:124
  syncable_cli::TelemetryClient::track_tools now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:128
  syncable_cli::TelemetryClient::track_analyze_folder now takes 2 parameters instead of 1, in /tmp/.tmpFItCG7/syncable-cli/src/telemetry/client.rs:138

--- failure unit_struct_changed_kind: unit struct changed kind ---

Description:
A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
        ref: https://github.com/rust-lang/cargo/pull/10871
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/unit_struct_changed_kind.ron

Failed in:
  struct JavaVulnerabilityChecker in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/checkers/java.rs:9
  struct JavaVulnerabilityChecker in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/checkers/java.rs:9
  struct JavaVulnerabilityChecker in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/checkers/java.rs:9
  struct PythonVulnerabilityChecker in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/checkers/python.rs:9
  struct PythonVulnerabilityChecker in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/checkers/python.rs:9
  struct PythonVulnerabilityChecker in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/checkers/python.rs:9
  struct GoVulnerabilityChecker in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/checkers/go.rs:9
  struct GoVulnerabilityChecker in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/checkers/go.rs:9
  struct GoVulnerabilityChecker in /tmp/.tmpFItCG7/syncable-cli/src/analyzer/vulnerability/checkers/go.rs:9
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.17.0](https://github.com/syncable-dev/syncable-cli/compare/v0.16.0...v0.17.0) - 2025-09-11

### Added

- test trigger
- improved telemtry and removed dublets

### Fixed

- .qodor folder for some reason wasn't corectly ignored

### Other

- added privacy-policy for telemetry
- fixed vulnerabilities output for different languages
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).