### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/syncable-dev/syncable-cli/compare/v0.17.0...v0.18.0) - 2025-09-11
+
+### Added
+
+- improved analyzer from false positives of voltagen and expo issues
+
+### Other
+
+- Merge pull request #159 from syncable-dev/develop
+
 ## [0.17.0](https://github.com/syncable-dev/syncable-cli/compare/v0.16.0...v0.17.0) - 2025-09-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.17.0 -> 0.18.0 (⚠ API breaking changes)

### ⚠ `syncable-cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ToolStatus.execution_path in /tmp/.tmpHISVDt/syncable-cli/src/analyzer/tool_management/detector.rs:12
  field ToolStatus.execution_path in /tmp/.tmpHISVDt/syncable-cli/src/analyzer/tool_management/detector.rs:12
  field ToolStatus.execution_path in /tmp/.tmpHISVDt/syncable-cli/src/analyzer/tool_management/detector.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.18.0](https://github.com/syncable-dev/syncable-cli/compare/v0.17.0...v0.18.0) - 2025-09-11

### Added

- improved analyzer from false positives of voltagen and expo issues

### Other

- Merge pull request #159 from syncable-dev/develop
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).