### PR TITLE
chore: release v0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.18.2](https://github.com/syncable-dev/syncable-cli/compare/v0.18.1...v0.18.2) - 2025-09-11
+
+### Added
+
+- fixed vulnerability scan for js and analyzer
+
 ## [0.18.1](https://github.com/syncable-dev/syncable-cli/compare/v0.18.0...v0.18.1) - 2025-09-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.18.1 -> 0.18.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.18.2](https://github.com/syncable-dev/syncable-cli/compare/v0.18.1...v0.18.2) - 2025-09-11

### Added

- fixed vulnerability scan for js and analyzer
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).