### PR TITLE
chore: release v0.18.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.18.5](https://github.com/syncable-dev/syncable-cli/compare/v0.18.4...v0.18.5) - 2025-09-29
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.18.4](https://github.com/syncable-dev/syncable-cli/compare/v0.18.3...v0.18.4) - 2025-09-29
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "syncable-cli"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncable-cli"
-version = "0.18.4"
+version = "0.18.5"
 edition = "2024"
 authors = ["Syncable Team"]
 description = "A Rust-based CLI that analyzes code repositories and generates Infrastructure as Code configurations"


### PR DESCRIPTION



## 🤖 New release

* `syncable-cli`: 0.18.4 -> 0.18.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>


## [0.18.5](https://github.com/syncable-dev/syncable-cli/compare/v0.18.4...v0.18.5) - 2025-09-29

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).